### PR TITLE
Made CI run every pushes in a Pull Request

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '2.7'
-      - name: Check branck
+      - name: Check branch
         if: github.event_name == 'pull_request'
         # github.head_ref: source branch of the pull request in a workflow run https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
         run: |

--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -3,10 +3,11 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
+  workflow_dispatch:  # Makes it be able to triggered manually https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  pull_request:
 
 env:
-  BASE_BRANCH_NAME: main
+  BASE_BRANCH_NAME: main  # when you edit the branch name here, also change `if` condition in `Deploy` phase
   HOSTING_BRANCH_NAME: gh-pages
   LOCAL_BRANCH_NAME: gh-pages-local
 
@@ -41,7 +42,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install markdown
           python makeAllEditions.py
-      - name: Commit
+      - name: Deploy
+        if: github.ref == 'refs/heads/main'
         run: |
           git add .
           git commit -m 'Generated static html files'

--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -3,10 +3,10 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:  # Makes it be able to triggered manually https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
   pull_request:
 
 env:
+  BASE_BRANCH_NAME: main
   HOSTING_BRANCH_NAME: gh-pages
   LOCAL_BRANCH_NAME: gh-pages-local
 
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '2.7'
+      - name: Check branck
+        if: github.event_name == 'pull_request'
+        # github.head_ref: source branch of the pull request in a workflow run https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+        run: |
+          $BASE_BRANCH_NAME = ${{ github.head_ref }}
       - name: Setup git
         run: |
           git config user.name "GitHub Actions Bot"
@@ -30,10 +35,9 @@ jobs:
         run: |
           git branch -d $LOCAL_BRANCH_NAME
       - name: Checkout
-        # ${GITHUB_REF##*/} represents the branch that triggeres this action https://stackoverflow.com/a/58034787
         run: |
           git fetch
-          git checkout ${GITHUB_REF##*/}
+          git checkout $BASE_BRANCH_NAME
           git pull
           git checkout -b $LOCAL_BRANCH_NAME
       - name: Build

--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 env:
-  BASE_BRANCH_NAME: main  # when you edit the branch name here, also change `if` condition in `Deploy` phase
   HOSTING_BRANCH_NAME: gh-pages
   LOCAL_BRANCH_NAME: gh-pages-local
 
@@ -31,9 +30,10 @@ jobs:
         run: |
           git branch -d $LOCAL_BRANCH_NAME
       - name: Checkout
+        # ${GITHUB_REF##*/} represents the branch that triggeres this action https://stackoverflow.com/a/58034787
         run: |
           git fetch
-          git checkout $BASE_BRANCH_NAME
+          git checkout ${GITHUB_REF##*/}
           git pull
           git checkout -b $LOCAL_BRANCH_NAME
       - name: Build
@@ -43,7 +43,7 @@ jobs:
           pip install markdown
           python makeAllEditions.py
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' # It only runs on main branch (not in a Pull Request)
         run: |
           git add .
           git commit -m 'Generated static html files'

--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name == 'pull_request'
         # github.head_ref: source branch of the pull request in a workflow run https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
         run: |
-          $BASE_BRANCH_NAME = ${{ github.head_ref }}
+          BASE_BRANCH_NAME=${{ github.head_ref }}
       - name: Setup git
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name == 'pull_request'
         # github.head_ref: source branch of the pull request in a workflow run https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
         run: |
-          BASE_BRANCH_NAME=${{ github.head_ref }}
+          echo "BASE_BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
       - name: Setup git
         run: |
           git config user.name "GitHub Actions Bot"


### PR DESCRIPTION
## Requirement 
- CI (GitHub Action) runs every pushes even they are on a Pull Request to check if the markdown files and the generator scripts work properly

## Implementation
- add `pull_request` trigger event in GitHub Action
- prevent deployment if the action runs on a Pull Request

## TODO
- [x] change the branch the action runs
  - it failed as expected https://github.com/ALife-Newsletter/Newsletter/pull/9
- [x] test it does NOT update the hosted files if the CI runs on a Pull Request
  - the deploy phase did not run on Pull Request https://github.com/ALife-Newsletter/Newsletter/actions/runs/2662158043
- [ ] test it does update the hosted files after a Pull Request is merged to the main branch (after this PR is merged)